### PR TITLE
Changed Markdown bullet for quote > or list -, depending a.tagname

### DIFF
--- a/pdfannots.py
+++ b/pdfannots.py
@@ -315,8 +315,10 @@ def prettyprint(annots, outlines, outfile, do_group, sections, wrapcol):
         if wrapcol:
             msg = tw1.fill(msglines[0]) + ('\n\n' if msglines[1:] else '') + '\n\n'.join(tw2.fill(m) for m in msglines[1:])
         else:
-            msg = " * " + msglines[0] + ('\n' if msglines[1:] else '') + '\n'.join('   ' + m for m in msglines[1:])
-
+            if a.tagname == 'Highlight':
+                msg = "> " + msglines[0] + ('\n' if msglines[1:] else '') + '\n'.join('   ' + m for m in msglines[1:])
+            else:
+                msg = "- " + msglines[0] + ('\n' if msglines[1:] else '') + '\n'.join('   ' + m for m in msglines[1:])
         # print it!
         print(msg + "\n", file=outfile)
 


### PR DESCRIPTION
I edited printannot() with an if statement that begins each line with a quote "> " if a.tagname is Highlight and else with a markdown list "- ". Thought it looked better, especially when running with --no-group