### PR TITLE
Brief output option

### DIFF
--- a/pdfannots.py
+++ b/pdfannots.py
@@ -391,6 +391,8 @@ class PrettyPrinter:
             return self.format_bullet(msgparas, quotepos, quotelen) + "\n"
 
     def printall(self, annots, outfile):
+        # Remove empty popup notes
+        annots = [a for a in annots if not (a.tagname == 'Text' and a.contents is None)]
         for a in annots:
             print(self.format_annot(a, a.tagname), file=outfile)
 


### PR DESCRIPTION
Thanks for putting together this script, it is super useful for me!

I would like to always output comments in the long form with the highlighted text quoted, so in this PR I suggest adding an option controlling when annotations are outputted as short form or long form.

PDFs for testing
[test-quotes.pdf](https://github.com/0xabu/pdfannots/files/4135045/test-quotes.pdf)
[test2.pdf](https://github.com/0xabu/pdfannots/files/4135046/test2.pdf)
