### PR TITLE
Various new printers (json, jsonl, csv, and todo)

### DIFF
--- a/pdfannots/cli.py
+++ b/pdfannots/cli.py
@@ -9,6 +9,7 @@ from . import __doc__, __version__, process_file
 from .printer import Printer
 from .printer.markdown import MarkdownPrinter, GroupedMarkdownPrinter
 from .printer.json import JsonPrinter
+from .printer.jsonl import JsonlPrinter
 
 
 def _float_or_disabled(x: str) -> typing.Optional[float]:
@@ -39,7 +40,7 @@ def parse_args() -> typing.Tuple[argparse.Namespace, LAParams]:
                         "columns per page. If unset, PDFMiner's layout detection logic is used.")
     g.add_argument("--keep-hyphens", dest="remove_hyphens", default=True, action="store_false",
                    help="When capturing text across a line break, don't attempt to remove hyphens.")
-    g.add_argument("-f", "--format", choices=["md", "json"], default="md",
+    g.add_argument("-f", "--format", choices=["md", "json", "jsonl"], default="md",
                    help="Output format (default: markdown).")
 
     g = p.add_argument_group('Options controlling markdown output')
@@ -124,6 +125,8 @@ def main() -> None:
         printer = (GroupedMarkdownPrinter if args.group else MarkdownPrinter)(args)
     elif args.format == "json":
         printer = JsonPrinter(args)
+    elif args.format == "jsonl":
+        printer = JsonlPrinter(args)
 
     def write_if_nonempty(s: str) -> None:
         if s:

--- a/pdfannots/cli.py
+++ b/pdfannots/cli.py
@@ -7,9 +7,11 @@ from pdfminer.layout import LAParams
 
 from . import __doc__, __version__, process_file
 from .printer import Printer
-from .printer.markdown import MarkdownPrinter, GroupedMarkdownPrinter
+from .printer.csv import CsvPrinter
 from .printer.json import JsonPrinter
 from .printer.jsonl import JsonlPrinter
+from .printer.markdown import GroupedMarkdownPrinter, MarkdownPrinter
+from .printer.todocsv import TodocsvPrinter
 
 
 def _float_or_disabled(x: str) -> typing.Optional[float]:
@@ -40,7 +42,7 @@ def parse_args() -> typing.Tuple[argparse.Namespace, LAParams]:
                         "columns per page. If unset, PDFMiner's layout detection logic is used.")
     g.add_argument("--keep-hyphens", dest="remove_hyphens", default=True, action="store_false",
                    help="When capturing text across a line break, don't attempt to remove hyphens.")
-    g.add_argument("-f", "--format", choices=["md", "json", "jsonl"], default="md",
+    g.add_argument("-f", "--format", choices=["md", "json", "jsonl", "csv", "todocsv"], default="md",
                    help="Output format (default: markdown).")
 
     g = p.add_argument_group('Options controlling markdown output')
@@ -127,6 +129,10 @@ def main() -> None:
         printer = JsonPrinter(args)
     elif args.format == "jsonl":
         printer = JsonlPrinter(args)
+    elif args.format == "csv":
+        printer = CsvPrinter(args)
+    elif args.format == "todocsv":
+        printer = TodocsvPrinter(args)
 
     def write_if_nonempty(s: str) -> None:
         if s:

--- a/pdfannots/printer/__init__.py
+++ b/pdfannots/printer/__init__.py
@@ -44,6 +44,7 @@ class DictBasedPrinter(Printer):
     all_fieldnames = [
         "type", "page", "start_xy", "prior_outline",
         "text", "contents", "author", "created"]
+    remove_hyphens = True
 
     def annot_to_dict(self, doc: Document, annot: Annotation) -> typing.Dict[str, typing.Any]:
         """Convert an annotation to a dictionary representation enabling further encoding."""

--- a/pdfannots/printer/__init__.py
+++ b/pdfannots/printer/__init__.py
@@ -41,6 +41,9 @@ class DictBasedPrinter(Printer):
     """
     Base class for printers formatting a dictionary like data-structure
     """
+    all_fieldnames = [
+        "type", "page", "start_xy", "prior_outline",
+        "text", "contents", "author", "created"]
 
     def annot_to_dict(self, doc: Document, annot: Annotation) -> typing.Dict[str, typing.Any]:
         """Convert an annotation to a dictionary representation enabling further encoding."""

--- a/pdfannots/printer/__init__.py
+++ b/pdfannots/printer/__init__.py
@@ -2,7 +2,7 @@ import abc
 import argparse
 import typing
 
-from ..types import Document
+from ..types import Annotation, Document
 
 
 class Printer(abc.ABC):
@@ -35,3 +35,37 @@ class Printer(abc.ABC):
     def end(self) -> str:
         """Called once after the final print_file call. Returns any final additional output."""
         return ''
+
+
+class DictBasedPrinter(Printer):
+    """
+    Base class for printers formatting a dictionary like data-structure
+    """
+
+    def annot_to_dict(self, doc: Document, annot: Annotation) -> typing.Dict[str, typing.Any]:
+        """Convert an annotation to a dictionary representation enabling further encoding."""
+        assert annot.pos
+
+        result = {
+            "type": annot.subtype.name,
+            "page": annot.pos.page.pageno + 1,
+            "start_xy": (annot.pos.x, annot.pos.y),
+        }
+
+        outline = doc.nearest_outline(annot.pos)
+        if outline:
+            result["prior_outline"] = outline.title
+
+        if annot.text:
+            result['text'] = annot.gettext(self.remove_hyphens)
+
+        if annot.contents:
+            result['contents'] = annot.contents
+
+        if annot.author:
+            result['author'] = annot.author
+
+        if annot.created:
+            result['created'] = annot.created.strftime('%Y-%m-%dT%H:%M:%S')
+
+        return result

--- a/pdfannots/printer/csv.py
+++ b/pdfannots/printer/csv.py
@@ -13,7 +13,8 @@ class CsvPrinter(DictBasedPrinter):
         self.remove_hyphens = args.remove_hyphens  # Whether to remove hyphens across a line break
 
         # Multiple input files in a single output require to have a filename
-        self.printfilename = args.printfilename if len(args.input) < 2 else True
+        self.printfilename = args.printfilename if (
+            not (hasattr(args, "input") and len(args.input) > 1)) else True
 
         self.memcsvfile = io.StringIO()
         self.writer = csv.DictWriter(self.memcsvfile, fieldnames=(

--- a/pdfannots/printer/csv.py
+++ b/pdfannots/printer/csv.py
@@ -1,0 +1,37 @@
+import argparse
+import io
+import typing
+import csv
+
+from ..types import Document
+from . import DictBasedPrinter
+
+
+class CsvPrinter(DictBasedPrinter):
+    def __init__(self, args: argparse.Namespace):
+        super().__init__(args)
+        self.remove_hyphens = args.remove_hyphens  # Whether to remove hyphens across a line break
+
+        # Multiple input files in a single output require to have a filename
+        self.printfilename = args.printfilename if len(args.input) < 2 else True
+
+        self.memcsvfile = io.StringIO()
+        self.writer = csv.DictWriter(self.memcsvfile, fieldnames=(
+            ['filename'] if self.printfilename else []) + self.all_fieldnames)
+
+    def begin(self) -> str:
+        self.writer.writeheader()
+        return self.memcsvfile.getvalue()
+
+    def print_file(self, filename: str, document: Document) -> typing.Iterator[str]:
+        # Empty the file buffer
+        self.memcsvfile.truncate(0)
+        self.memcsvfile.seek(0)
+
+        for a in document.iter_annots():
+            ad = self.annot_to_dict(document, a)
+
+            if self.printfilename:
+                ad["filename"] = filename
+            self.writer.writerow(ad)
+        yield self.memcsvfile.getvalue()

--- a/pdfannots/printer/json.py
+++ b/pdfannots/printer/json.py
@@ -13,7 +13,7 @@ class JsonPrinter(Printer):
 
         # We overload the printfilename option to decide whether to emit a structured
         # JSON file with one entry per file, or just a flat array of annotations.
-        self.printfilename = args.printfilename
+        self.printfilename = args.printfilename if len(args.input) < 2 else True
         self.seen_first = False
 
     def begin(self) -> str:
@@ -22,21 +22,10 @@ class JsonPrinter(Printer):
     def end(self) -> str:
         return '\n]\n' if self.printfilename else '\n'
 
-    def print_file(
-        self,
-        filename: str,
-        document: Document
-    ) -> typing.Iterator[str]:
-
+    def print_file(self, filename: str, document: Document) -> typing.Iterator[str]:
         # insert a , between successive files
         if self.seen_first:
-            if self.printfilename:
-                yield ',\n'
-            else:
-                # The flat array format is incompatible with multiple input files
-                # TODO: Ideally we'd catch this at invocation time
-                raise RuntimeError("When used with multiple input files, the "
-                                   "JSON formatter requires --print-filename")
+            yield ',\n'
         else:
             self.seen_first = True
 

--- a/pdfannots/printer/json.py
+++ b/pdfannots/printer/json.py
@@ -2,11 +2,11 @@ import argparse
 import json
 import typing
 
-from . import Printer
-from ..types import Annotation, Document
+from . import DictBasedPrinter
+from ..types import Document
 
 
-class JsonPrinter(Printer):
+class JsonPrinter(DictBasedPrinter):
     def __init__(self, args: argparse.Namespace):
         super().__init__(args)
         self.remove_hyphens = args.remove_hyphens  # Whether to remove hyphens across a line break
@@ -40,30 +40,3 @@ class JsonPrinter(Printer):
         yield from json.JSONEncoder(indent=2).iterencode(
             dictobj if self.printfilename else annot_dicts)
 
-    def annot_to_dict(self, doc: Document, annot: Annotation) -> typing.Dict[str, typing.Any]:
-        """Convert an annotation to a dictionary representation suitable for JSON encoding."""
-        assert annot.pos
-
-        result = {
-            "type": annot.subtype.name,
-            "page": annot.pos.page.pageno + 1,
-            "start_xy": (annot.pos.x, annot.pos.y),
-        }
-
-        outline = doc.nearest_outline(annot.pos)
-        if outline:
-            result["prior_outline"] = outline.title
-
-        if annot.text:
-            result['text'] = annot.gettext(self.remove_hyphens)
-
-        if annot.contents:
-            result['contents'] = annot.contents
-
-        if annot.author:
-            result['author'] = annot.author
-
-        if annot.created:
-            result['created'] = annot.created.strftime('%Y-%m-%dT%H:%M:%S')
-
-        return result

--- a/pdfannots/printer/json.py
+++ b/pdfannots/printer/json.py
@@ -12,7 +12,8 @@ class JsonPrinter(DictBasedPrinter):
         self.remove_hyphens = args.remove_hyphens  # Whether to remove hyphens across a line break
 
         # Multiple input files in a single output require to have a filename
-        self.printfilename = args.printfilename if len(args.input) < 2 else True
+        self.printfilename = args.printfilename if (
+            not (hasattr(args, "input") and len(args.input) > 1)) else True
         self.seen_first = False
 
     def begin(self) -> str:

--- a/pdfannots/printer/jsonl.py
+++ b/pdfannots/printer/jsonl.py
@@ -6,31 +6,27 @@ from . import DictBasedPrinter
 from ..types import Document
 
 
-class JsonPrinter(DictBasedPrinter):
+class JsonlPrinter(DictBasedPrinter):
     def __init__(self, args: argparse.Namespace):
         super().__init__(args)
         self.remove_hyphens = args.remove_hyphens  # Whether to remove hyphens across a line break
 
-        # Multiple input files in a single output require to have a filename
-        self.printfilename = args.printfilename if len(args.input) < 2 else True
         self.seen_first = False
 
-    def begin(self) -> str:
-        return '{\n' if self.printfilename else ''
-
     def end(self) -> str:
-        return '\n}\n' if self.printfilename else '\n'
+        return '\n'
 
     def print_file(self, filename: str, document: Document) -> typing.Iterator[str]:
-        # insert a , between successive files
+        # insert a newline between successive files
         if self.seen_first:
-            yield ',\n'
+            yield '\n'
         else:
             self.seen_first = True
 
         annot_dicts = [self.annot_to_dict(document, a) for a in document.iter_annots()]
+        dictobj = {
+            "file": filename,
+            "annotations": annot_dicts
+        }
 
-        if self.printfilename:
-            yield '  "%s": ' % filename
-
-        yield from json.JSONEncoder(indent=4).iterencode(annot_dicts)
+        yield from json.JSONEncoder(indent=None).iterencode(dictobj)

--- a/pdfannots/printer/todocsv.py
+++ b/pdfannots/printer/todocsv.py
@@ -1,0 +1,25 @@
+from .csv import CsvPrinter
+
+import typing
+from ..types import Annotation, Document
+
+
+class TodocsvPrinter(CsvPrinter):
+    """
+    Create a todo-list of all comments to keep track, which comments were addressed
+    and add an option to extend and work with them within spreadsheets.
+    """
+
+    all_fieldnames = ["location", "context", "explanation"]
+
+    def annot_to_dict(self, doc: Document, annot: Annotation) -> typing.Dict[str, typing.Any]:
+        a = super().annot_to_dict(doc, annot)
+
+        if annot.pos:
+            o = doc.nearest_outline(annot.pos)
+
+        return {
+            'location': ("p%d" % a['page']) + (": " + o.title if o else ""),
+            "context": a.get('text', '-'),
+            "explanation": a.get('contents', '')
+        }


### PR DESCRIPTION
Thank you for the new printer interface. It enabled me to add three new output formats:

1. **jsonl** Similar as the original json, but with the output of one file per line. The wrapping in a list, especially the final ending `]` from the regular json output is not required in this format. Hence, parsing can happen on the fly and various, large files can be parsed in a pipeline, while the output can be processed line wise.  Furthermore, I adjusted the original json output to make it more diverse than this output format, but feel free to reject or split these changes.
2. **csv** Larger amounts of data can be handled easily in spreadsheets. This is a very simple but efficient way to work with pdf comments in Excel or LibreOffice calc. The data structure is the same as in the json printers.
3. **todocsv** This is a special variant of a csv file. When I work with comments in a pdf, these comments are feedback to texts that I have written myself. Depending on the size of the text and the amount of comments, I struggled with keeping track and not missing a comment in the pdf file. Thus, I use this format in a spreadsheet as a starting point to enrich the feedback with my own comments with restructuring, merging and tracking.

I hope you will find these printers beneficial for the codebase. Please let me know if there is anything I should adjust or extend. I have added a test cases that highlights the most basic usages. Thanks a lot for your neat helper!