### PR TITLE
Handle outlines without x/y coordinates

### DIFF
--- a/pdfannots/__init__.py
+++ b/pdfannots/__init__.py
@@ -126,10 +126,17 @@ def _get_outlines(doc: PDFDocument) -> typing.Iterator[Outline]:
 
             if not isinstance(pageref, (int, pdftypes.PDFObjRef)):
                 logger.warning("Unsupported pageref in outline: %s", pageref)
-            elif not (isinstance(targetx, (int, float)) and isinstance(targety, (int, float))):
-                logger.warning("Unsupported target in outline: (%s, %s)", targetx, targety)
             else:
-                yield Outline(title, pageref, (targetx, targety))
+                if targetx is None or targety is None:
+                    # Treat as a general reference to the page
+                    target = None
+                else:
+                    target = (targetx, targety)
+                    if not all(lambda v: isinstance(v, (int, float)) for v in target):
+                        logger.warning("Unsupported target in outline: (%r, %r)", targetx, targety)
+                        target = None
+
+                yield Outline(title, pageref, target)
 
 
 class PDFNoPageLabels(Exception):

--- a/pdfannots/types.py
+++ b/pdfannots/types.py
@@ -394,7 +394,7 @@ class Outline(ObjectWithPos):
         self,
         title: str,
         pageref: UnresolvedPage,
-        target: typing.Tuple[float, float]
+        target: typing.Optional[typing.Tuple[float, float]]
     ):
         super().__init__()
         self.title = title
@@ -412,7 +412,12 @@ class Outline(ObjectWithPos):
         else:
             assert self.pageref == page.pageno
 
-        targetx, targety = self.target
+        if self.target is None:
+            # XXX: "first" point on the page, assuming left-to-right top-to-bottom order
+            (targetx, targety) = (page.mediabox.x0, page.mediabox.y1)
+        else:
+            (targetx, targety) = self.target
+
         self.pos = Pos(page, targetx, targety)
 
 


### PR DESCRIPTION
Rather than ignoring them, treat outlines without an X or Y coordinate as referring to the start of the page.

Better fix for issue #54