### PR TITLE
Change Markdown output for deletions from HTML <del>foo</del> to ~~foo~~

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) Microsoft Corporation. All rights reserved. 
+Copyright (c) Microsoft Corporation (2016-2022) and Andrew Baumann (2022-). All rights reserved.
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the

--- a/pdfannots/printer/markdown.py
+++ b/pdfannots/printer/markdown.py
@@ -199,7 +199,7 @@ class MarkdownPrinter(Printer):
         if post:
             post = trim_context(post, keep_right=False)
 
-        return pre + '<del>' + text + '</del>' + post
+        return pre + '~~' + text + '~~' + post
 
     def format_annot(
         self,


### PR DESCRIPTION
Classic Markdown lacks a standard format for deletions, but allows the use of HTML tags. HotCRP doesn't support HTML tags, but does support the ~~ syntax, which is apparently quite common. Because the primary motivation of this tool is (a) legible plain text output, and (b) HotCRP reviews, this feels like a better choice.