### PR TITLE
Minor usability improvements with Skim PDF

### DIFF
--- a/pdfannots/__init__.py
+++ b/pdfannots/__init__.py
@@ -406,6 +406,10 @@ def process_file(
         page.annots.sort()
         page.outlines.sort()
 
+        # Give the annotations a chance to update their internals
+        for a in page.annots:
+            a.postprocess()
+
     emit_progress("\n")
 
     device.close()

--- a/pdfannots/__init__.py
+++ b/pdfannots/__init__.py
@@ -384,9 +384,11 @@ def process_file(
         # Construct Annotation objects, and append them to the page.
         for pa in pdftypes.resolve1(pdfpage.annots) if pdfpage.annots else []:
             if isinstance(pa, pdftypes.PDFObjRef):
-                annot = _mkannotation(pdftypes.dict_value(pa), page)
-                if annot is not None:
-                    page.annots.append(annot)
+                annot_dict = pdftypes.dict_value(pa)
+                if annot_dict:  # Would be empty if pa is a broken ref
+                    annot = _mkannotation(annot_dict, page)
+                    if annot is not None:
+                        page.annots.append(annot)
             else:
                 logger.warning("Unknown annotation: %s", pa)
 

--- a/pdfannots/types.py
+++ b/pdfannots/types.py
@@ -394,6 +394,7 @@ class Annotation(ObjectWithPos):
         if self.contents and self.text and ''.join(self.text).strip() == self.contents.strip():
             self.contents = None
 
+
 UnresolvedPage = typ.Union[int, PDFObjRef]
 """A reference to a page that is *either* a page number, or a PDF object ID."""
 

--- a/pdfannots/types.py
+++ b/pdfannots/types.py
@@ -385,6 +385,14 @@ class Annotation(ObjectWithPos):
         return (merge_lines(self.pre_context or '', remove_hyphens, strip_space=False),
                 merge_lines(self.post_context or '', remove_hyphens, strip_space=False))
 
+    def postprocess(self):
+        """Update internal state once all text and context has been captured."""
+        # The Skim PDF reader (https://skim-app.sourceforge.io/) creates annotations whose
+        # default initial contents are a copy of the selected text. Unless the user goes to
+        # the trouble of editing each annotation, this goes badly for us because we have
+        # duplicate text and contents (e.g., for simple highlights and strikeout).
+        if self.contents and self.text and ''.join(self.text).strip() == self.contents.strip():
+            self.contents = None
 
 UnresolvedPage = typ.Union[int, PDFObjRef]
 """A reference to a page that is *either* a page number, or a PDF object ID."""

--- a/pdfannots/types.py
+++ b/pdfannots/types.py
@@ -385,7 +385,7 @@ class Annotation(ObjectWithPos):
         return (merge_lines(self.pre_context or '', remove_hyphens, strip_space=False),
                 merge_lines(self.post_context or '', remove_hyphens, strip_space=False))
 
-    def postprocess(self):
+    def postprocess(self) -> None:
         """Update internal state once all text and context has been captured."""
         # The Skim PDF reader (https://skim-app.sourceforge.io/) creates annotations whose
         # default initial contents are a copy of the selected text. Unless the user goes to


### PR DESCRIPTION
 * Ignore a new form of slightly-broken PDF file
 * Ignore annotation contents that are an exact copy of the selected text