### PR TITLE
feat: add logseq output format (md + edn files)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 [![PyPI version](https://img.shields.io/pypi/v/pdfannots)](https://pypi.org/project/pdfannots/)
 
 This program extracts annotations (highlights, comments, etc.) from a PDF file,
-and formats them as Markdown or exports them to JSON. It is primarily intended
-for use in reviewing submissions to scientific conferences/journals.
+and formats them either as Markdown, as JSON, or as Markdown coupled with EDN files (for example for use with [LogSeq](https://github.com/logseq/logseq/issues)).
+It is primarily intended for use in reviewing submissions to scientific conferences/journals.
 
 ![Sample/demo of pdfannots extracting Markdown from an annotated PDF](doc/demo.png)
 

--- a/pdfannots/__init__.py
+++ b/pdfannots/__init__.py
@@ -94,7 +94,7 @@ def _mkannotation(
         created = decode_datetime(createds)
 
     return Annotation(page, annot_type, quadpoints, rect,
-                      contents, author=author, created=created)
+                      contents, color=pa.get('C'), author=author, created=created)
 
 
 def _get_outlines(doc: PDFDocument) -> typ.Iterator[Outline]:

--- a/pdfannots/printer/edn.py
+++ b/pdfannots/printer/edn.py
@@ -39,8 +39,8 @@ def annot_to_dict(
             "rects": [
                 {
                     "x1": b.x0,
-                    "x2": b.x1,
                     "y1": b.y0,
+                    "x2": b.x1,
                     "y2": b.y1,
                     "width": b.get_width(),
                     "height": b.get_height(),

--- a/pdfannots/printer/edn.py
+++ b/pdfannots/printer/edn.py
@@ -1,0 +1,115 @@
+from pathlib import Path
+import uuid
+import json
+import typing as typ
+
+from . import Printer
+from ..types import Annotation, Document
+
+
+def annot_to_dict(
+    doc: Document,
+    annot: Annotation,
+    remove_hyphens: bool
+) -> typ.Dict[str, typ.Any]:
+    """Convert an annotation to a dictionary representation suitable for JSON encoding."""
+    assert annot.pos
+
+    result = {
+        "id #uuid": str(uuid.uuid4()),
+        "page": annot.pos.page.pageno + 1,
+    }
+
+    if annot.boxes:
+        bd_x1 = min([b.x0 for b in annot.boxes])
+        bd_y1 = min([b.y0 for b in annot.boxes])
+        bd_x2 = max([b.x1 for b in annot.boxes])
+        bd_y2 = max([b.y1 for b in annot.boxes])
+        bd_w = int(bd_x2 - bd_x1)
+        bd_h = int(bd_y2 - bd_y1)
+        result['position'] = {
+            "bounding": {
+                "x1": bd_x1,
+                "y1": bd_y1,
+                "x2": bd_x2,
+                "y2": bd_y2,
+                "width": bd_w,
+                "height": bd_h,
+            },
+            "rects": [
+                {
+                    "x1": b.x0,
+                    "x2": b.x1,
+                    "y1": b.y0,
+                    "y2": b.y1,
+                    "width": b.get_width(),
+                    "height": b.get_height(),
+                }
+                for b in annot.boxes
+            ],
+            "page": result["page"],
+        }
+
+
+    if annot.text:
+        result['content'] = {
+                "text": annot.gettext(remove_hyphens)
+                }
+
+    result["properties"] = {"color": "yellow"}
+
+    return result
+
+def idt(n):
+    "simple indenter"
+    return "\t" * n
+
+def edn_var_formatter(text, var):
+    return text.replace(f'"{var}": ', f':{var} ')
+
+
+class EDNPrinter(Printer):
+    def __init__(self, *, remove_hyphens: bool) -> None:
+        self.remove_hyphens = remove_hyphens  # Whether to remove hyphens across a line break
+        self.seen_first = False
+
+    def end(self) -> str:
+        return '\n'
+
+    def print_file(
+        self,
+        filename: str,
+        document: Document
+    ) -> typ.Iterator[str]:
+        if self.seen_first:
+            # The flat array format is incompatible with multiple input files
+            # TODO: Ideally we'd catch this at invocation time
+            raise RuntimeError("The Logseq output format does not support multiple files.")
+        else:
+            self.seen_first = True
+
+        annots = {
+                "highlights": [annot_to_dict(document, a, self.remove_hyphens) for a in document.iter_annots()]
+                }
+
+        # create the md file alongside the annotations 
+        md = "file-path:: ../assets/" + Path(filename).name + "\n\n"
+        for an in annots["highlights"]:
+            md += "- " + an["content"]["text"] + "\n"
+            md += "  ls-type:: annotation\n"
+            md += "  hl-page:: " + str(an["page"]) + "\n"
+            md += "  hl-color:: yellow\n"
+            md += "  id:: " + an["id #uuid"] + "\n"
+
+
+        edn = json.dumps(annots, indent=2)
+
+        for var in ["x1", "y1", "x2", "y2", "width", "height", "id #uuid",
+                "page", "position", "content", "text", "properties",
+                "color", "rects", "bounding", "highlights"]:
+            edn = edn_var_formatter(edn, var)
+
+        return {
+                "markdown_part": md,
+                "edn_part": edn,
+            }

--- a/pdfannots/printer/edn.py
+++ b/pdfannots/printer/edn.py
@@ -20,11 +20,12 @@ def annot_to_dict(
         "page": annot.pos.page.pageno + 1,
     }
 
+
     if annot.boxes:
-        bd_x1 = min([b.x0 for b in annot.boxes])
-        bd_y1 = min([b.y0 for b in annot.boxes])
-        bd_x2 = max([b.x1 for b in annot.boxes])
-        bd_y2 = max([b.y1 for b in annot.boxes])
+        bd_x1 = annot.rect[0]
+        bd_y1 = annot.rect[2]
+        bd_x2 = annot.rect[1]
+        bd_y2 = annot.rect[3]
         bd_w = int(bd_x2 - bd_x1)
         bd_h = int(bd_y2 - bd_y1)
         result['position'] = {

--- a/pdfannots/printer/edn.py
+++ b/pdfannots/printer/edn.py
@@ -4,7 +4,7 @@ import json
 import typing as typ
 
 from . import Printer
-from ..types import Annotation, Document
+from ..types import Annotation, Document, AnnotationType
 
 
 def annot_to_dict(
@@ -51,10 +51,17 @@ def annot_to_dict(
         }
 
 
-    if annot.text:
-        result['content'] = {
-                "text": annot.gettext(remove_hyphens)
+    if annot.subtype in [AnnotationType.Square, AnnotationType.Ink]:
+        result["content"] = {
+                "text": "[:span]",
+                "image": "TODO",  # TODO, render an image here and store it
+                # with as name the UNIX timestamp
                 }
+    else:
+        if annot.text:
+            result['content'] = {
+                    "text": annot.gettext(remove_hyphens)
+                    }
 
     result["properties"] = {"color": annot.colorname}
 
@@ -106,7 +113,7 @@ class EDNPrinter(Printer):
 
         for var in ["x1", "y1", "x2", "y2", "width", "height", "id #uuid",
                 "page", "position", "content", "text", "properties",
-                "color", "rects", "bounding", "highlights"]:
+                "color", "rects", "bounding", "highlights", "image"]:
             edn = edn_var_formatter(edn, var)
 
         return {

--- a/pdfannots/printer/edn.py
+++ b/pdfannots/printer/edn.py
@@ -56,7 +56,7 @@ def annot_to_dict(
                 "text": annot.gettext(remove_hyphens)
                 }
 
-    result["properties"] = {"color": "yellow"}
+    result["properties"] = {"color": annot.colorname}
 
     return result
 
@@ -98,7 +98,7 @@ class EDNPrinter(Printer):
             md += "- " + an["content"]["text"] + "\n"
             md += "  ls-type:: annotation\n"
             md += "  hl-page:: " + str(an["page"]) + "\n"
-            md += "  hl-color:: yellow\n"
+            md += "  hl-color:: " + str(an["properties"]["color"]) + "\n"
             md += "  id:: " + an["id #uuid"] + "\n"
 
 

--- a/pdfannots/printer/json.py
+++ b/pdfannots/printer/json.py
@@ -35,6 +35,9 @@ def annot_to_dict(
     if annot.created:
         result['created'] = annot.created.strftime('%Y-%m-%dT%H:%M:%S')
 
+    if annot.boxes:
+        result['boxes'] = [{"x0": b.x0, "x1": b.x1, "y0":b.y0, "y1":b.y1} for b in annot.boxes]
+
     return result
 
 

--- a/pdfannots/types.py
+++ b/pdfannots/types.py
@@ -265,6 +265,9 @@ class AnnotationType(enum.Enum):
     # Free-form text written somewhere on the page.
     FreeText = enum.auto()
 
+    # Free hand drawing
+    Ink = enum.auto()
+
 
 class Annotation(ObjectWithPos):
     """
@@ -327,6 +330,7 @@ class Annotation(ObjectWithPos):
         self.pre_context = None
         self.post_context = None
         self.boxes = boxes
+        self.rect = rect
         self.last_charseq = 0
 
     def __repr__(self) -> str:

--- a/pdfannots/types.py
+++ b/pdfannots/types.py
@@ -335,8 +335,6 @@ class Annotation(ObjectWithPos):
         assert rect or boxes
         (x0, y0, x1, y1) = rect if rect else boxes[0].get_coords()
         # XXX: assume left-to-right top-to-bottom text
-#        if subtype == AnnotationType.Ink:
-#            breakpoint()
         pos = Pos(page, min(x0, x1), max(y0, y1))
         super().__init__(pos)
 

--- a/pdfannots/types.py
+++ b/pdfannots/types.py
@@ -29,11 +29,11 @@ BoxCoords = typ.Tuple[float, float, float, float]
 # http://colormine.org/delta-e-calculator
 # http://zschuessler.github.io/DeltaE/learn/
 COLORS = {
-    'blue'   : sRGBColor(0.294117647059, 0.588235294118, 1.0           ),
     'yellow' : sRGBColor(1.0           , 0.78431372549 , 0.196078431373),
+    'red'    : sRGBColor(1.0           , 0.0,            0.0),
     'green'  : sRGBColor(0.78431372549 , 1             , 0.392156862745),
-    'lilac'  : sRGBColor(0.78431372549 , 0.392156862745, 0.78431372549 ),
-    'rose'   : sRGBColor(1.0           , 0.196078431373, 0.392156862745)
+    'blue'   : sRGBColor(0.294117647059, 0.588235294118, 1.0),
+    'purple'  : sRGBColor(0.78431372549 , 0.392156862745, 0.78431372549 ),
 }
 
 


### PR DESCRIPTION
Hi,
I needed a way to import my already annotated pdf into logseq and ended up forking your project to create this.

I decided to make the PR to get some feedback.

I hope you don't mind!

- new: add boxes information to json format
- feat: support edn output for logseq



edit : it seems the coordinate system of logseq and pdfannots differ. If you have any idea let me know!