### PR TITLE
[WIP] Add support for caret

### DIFF
--- a/pdfannots/printer/json.py
+++ b/pdfannots/printer/json.py
@@ -21,6 +21,8 @@ def annot_to_dict(
         "prior_outline": getattr(doc.nearest_outline(annot.pos), 'title', None),
         "text": annot.gettext(remove_hyphens),
         "contents": annot.contents,
+        "pre_context": annot.pre_context,
+        "post_context": annot.post_context,
         "author": annot.author,
         "created": annot.created.strftime('%Y-%m-%dT%H:%M:%S') if annot.created else None,
         "color": ('#' + annot.color.ashex()) if annot.color else None

--- a/pdfannots/printer/markdown.py
+++ b/pdfannots/printer/markdown.py
@@ -4,7 +4,7 @@ import textwrap
 import typing as typ
 
 from . import Printer
-from ..types import RGB, AnnotationType, Pos, Annotation, Document
+from ..types import RGB, AnnotationType, Pos, Annotation, Document, ANNOT_SUBTYPES
 
 logger = logging.getLogger('pdfannots')
 
@@ -359,8 +359,18 @@ class GroupedMarkdownPrinter(MarkdownPrinter):
                     extra = None
 
                     if a.subtype == AnnotationType.StrikeOut:
-                        extra = "suggested deletion" 
+                        irt_type = None
+
+                        if a.in_reply_to:
+                            irt_subtype = a.in_reply_to.get('Subtype')
+                            if irt_subtype:
+                                irt_type = ANNOT_SUBTYPES[irt_subtype]
+                        
+                        if a.contents and irt_type == AnnotationType.Caret:
+                            extra = "suggested replacement" 
+                        else:
+                            extra = "suggested deletion"
                     elif a.subtype == AnnotationType.Caret:
-                        extra = "suggested replacement"
+                        extra = "suggested insertion"
 
                     yield self.format_annot(a, document, extra)

--- a/pdfannots/printer/markdown.py
+++ b/pdfannots/printer/markdown.py
@@ -223,7 +223,7 @@ class MarkdownPrinter(Printer):
                    if annot.contents else [])
 
         if annot.has_context():
-            assert annot.subtype == AnnotationType.StrikeOut
+            assert annot.subtype == AnnotationType.StrikeOut or annot.subtype == AnnotationType.Caret
             text = self.merge_strikeout_context(annot, text)
 
         # we are either printing: item text and item contents, or one of the two
@@ -276,7 +276,8 @@ class MarkdownPrinter(Printer):
 
 class GroupedMarkdownPrinter(MarkdownPrinter):
     ANNOT_NITS = frozenset({
-        AnnotationType.Squiggly, AnnotationType.StrikeOut, AnnotationType.Underline})
+        AnnotationType.Squiggly, AnnotationType.StrikeOut, AnnotationType.Caret, 
+        AnnotationType.Underline})
     ALL_SECTIONS = ["highlights", "comments", "nits"]
 
     def __init__(
@@ -355,5 +356,11 @@ class GroupedMarkdownPrinter(MarkdownPrinter):
             if nits and secname == 'nits':
                 yield fmt_header("Nits")
                 for a in nits:
-                    extra = "suggested deletion" if a.subtype == AnnotationType.StrikeOut else None
+                    extra = None
+
+                    if a.subtype == AnnotationType.StrikeOut:
+                        extra = "suggested deletion" 
+                    elif a.subtype == AnnotationType.Caret:
+                        extra = "suggested replacement"
+
                     yield self.format_annot(a, document, extra)

--- a/pdfannots/types.py
+++ b/pdfannots/types.py
@@ -260,6 +260,7 @@ class AnnotationType(enum.Enum):
     Squiggly = enum.auto()
     StrikeOut = enum.auto()
     Underline = enum.auto()
+    Caret = enum.auto()
 
     # A single rectangle, that is abused by some Apple tools to render custom
     # highlights. We do not attempt to capture the affected text.
@@ -282,7 +283,7 @@ class Annotation(ObjectWithPos):
         color        RGB color of the annotation
         last_charseq Sequence number of the most recent character in text
 
-    Attributes updated only for StrikeOut annotations:
+    Attributes updated for StrikeOut and Caret annotations:
         pre_context  Text captured just prior to the beginning of 'text'
         post_context Text captured just after the end of 'text'
     """
@@ -363,7 +364,7 @@ class Annotation(ObjectWithPos):
 
     def wants_context(self) -> bool:
         """Returns true if this annotation type should include context."""
-        return self.subtype == AnnotationType.StrikeOut
+        return self.subtype == AnnotationType.StrikeOut or self.subtype == AnnotationType.Caret
 
     def set_pre_context(self, pre_context: str) -> None:
         assert self.pre_context is None


### PR DESCRIPTION
Attemps to add support for replace annotations:

![image](https://github.com/0xabu/pdfannots/assets/21097167/3d88e049-3ac3-466f-859a-2bb3fad5cbee)

The replace text annotation is made of a `StrikeOut` and a `Caret` annotation. The `StrikeOut` part is the line, and the little arrow is the `Caret` annotation. Since they appear as separate annotations, this hacky implementation modifies the content of the last `StrikeOut` annotation when it sees a `Caret` annotation.

However, I noticed that every annotation here appears twice:

https://github.com/0xabu/pdfannots/blob/f3d80dbcfbb15ffce5e3bc9ff45f269958925bfb/pdfannots/__init__.py#L396-L405

Attempts to resolve #61 

- Caret annotations were introduced in the v1.5 spec. Page 616 of the [PDF Reference 1.7](https://opensource.adobe.com/dc-acrobat-sdk-docs/pdfstandards/pdfreference1.7old.pdf)
- [Example PDF](https://github.com/user-attachments/files/15981389/test.pdf)

@0xabu Do you have any thoughts on this?
