### PR TITLE
Use RT field to distinguish groups (like strikeout & caret) from actual replies

### DIFF
--- a/pdfannots/__init__.py
+++ b/pdfannots/__init__.py
@@ -106,9 +106,18 @@ def _mkannotation(
         createds = pdfminer.utils.decode_text(createds)
         created = decode_datetime(createds)
 
+    in_reply_to = pa.get('IRT')
+    is_group = False
+    if in_reply_to is not None:
+        reply_type = pa.get('RT')
+        if reply_type is PSLiteralTable.intern('Group'):
+            is_group = True
+        elif not (reply_type is None or reply_type is PSLiteralTable.intern('R')):
+            logger.warning("Unexpected RT=%s, treated as R", reply_type)
+
     return Annotation(page, annot_type, quadpoints=quadpoints, rect=rect, name=name,
                       contents=contents, author=author, created=created, color=rgb,
-                      in_reply_to_ref=pa.get('IRT'))
+                      in_reply_to_ref=in_reply_to, is_group_child=is_group)
 
 
 def _get_outlines(doc: PDFDocument) -> typ.Iterator[Outline]:

--- a/pdfannots/printer/json.py
+++ b/pdfannots/printer/json.py
@@ -25,8 +25,7 @@ def annot_to_dict(
         "author": annot.author,
         "created": annot.created.strftime('%Y-%m-%dT%H:%M:%S') if annot.created else None,
         "color": ('#' + annot.color.ashex()) if annot.color else None,
-        "in_reply_to": (annot.in_reply_to.name if annot.in_reply_to and annot.in_reply_to.name
-                        else None),
+        "in_reply_to": annot.in_reply_to.name if annot.in_reply_to else None,
     }
 
     # Remove keys with None values in nested dictionary and return
@@ -62,5 +61,6 @@ class JsonPrinter(Printer):
         else:
             self.seen_first = True
 
-        annots = [annot_to_dict(document, a, self.remove_hyphens) for a in document.iter_annots()]
+        annots = [annot_to_dict(document, a, self.remove_hyphens)
+                  for a in document.iter_annots(include_replies=True)]
         yield from json.JSONEncoder(indent=2, ensure_ascii=self.ensure_ascii).iterencode(annots)

--- a/tests.py
+++ b/tests.py
@@ -278,14 +278,17 @@ class CaretAnnotations(ExtractionTestBase):
 
     def test(self) -> None:
         self.assertEqual(len(self.annots), 5)
-        self.assertEqual(self.annots[0].subtype, AnnotationType.StrikeOut)
-        self.assertEqual(self.annots[0].gettext(), 'Adobe Acrobat Reader')
-        self.assertEqual(self.annots[3].subtype, AnnotationType.Caret)
-        self.assertEqual(self.annots[3].contents, 'Google Chrome')
-        self.assertEqual(self.annots[0].in_reply_to, self.annots[3])
-        self.assertEqual(self.annots[3].replies, [self.annots[0]])
-        self.assertEqual(self.annots[0].replies, [])
-        self.assertEqual(self.annots[3].in_reply_to, None)
+        a = self.annots[0]
+        self.assertEqual(a.subtype, AnnotationType.StrikeOut)
+        self.assertEqual(a.gettext(), 'Adobe Acrobat Reader')
+        self.assertTrue(a.is_group_child)
+        self.assertEqual(a.group_children, [])
+        g = self.annots[3]
+        self.assertEqual(g.subtype, AnnotationType.Caret)
+        self.assertEqual(g.contents, 'Google Chrome')
+        self.assertFalse(g.is_group_child)
+        self.assertEqual(g.group_children, [a])
+        self.assertEqual(g.get_child_by_type(AnnotationType.StrikeOut), a)
 
 
 class PrinterTestBase(unittest.TestCase):


### PR DESCRIPTION
This cleans up our data model a tiny bit