### PR TITLE
Use PLAYA and PAVÉS instead of pdfminer.six

### DIFF
--- a/pdfannots/__init__.py
+++ b/pdfannots/__init__.py
@@ -398,11 +398,17 @@ def process_file(
 
     # Iterate over all the pages, constructing page objects.
     result = Document()
-    for pdfpage in doc.pages:
+    # PLAYA will make up page labels if they don't exist (this is
+    # arguably a bug in PLAYA) so use the explicit ones only.
+    try:
+        page_labels = doc.page_labels
+    except (KeyError, ValueError):
+        page_labels = itertools.repeat(None)
+    for pdfpage, page_label in zip(doc.pages, page_labels):
         pageno = pdfpage.page_idx
         emit_progress(" %d" % (pageno + 1))
 
-        page = Page(pageno, pdfpage.pageid, pdfpage.label, pdfpage.mediabox, columns_per_page)
+        page = Page(pageno, pdfpage.pageid, page_label, pdfpage.mediabox, columns_per_page)
         result.pages.append(page)
 
         # Resolve any outlines referring to this page, and link them to the page.

--- a/pdfannots/cli.py
+++ b/pdfannots/cli.py
@@ -3,7 +3,7 @@ import logging
 import sys
 import typing as typ
 
-from pdfminer.layout import LAParams
+from paves.miner import LAParams
 
 from . import __doc__, __version__, process_file
 from .printer import Printer

--- a/pdfannots/types.py
+++ b/pdfannots/types.py
@@ -7,8 +7,7 @@ import functools
 import logging
 import typing as typ
 
-from pdfminer.layout import LTComponent, LTText
-from pdfminer.pdftypes import PDFObjRef
+from paves.miner import LTComponent, LTText, PDFObjRef
 
 from .utils import merge_lines
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 name = "pdfannots"
 dynamic = ["version"]
 requires-python = ">=3.8"
-dependencies = ["paves", "playa-pdf>=0.3.0"]
+dependencies = ["paves", "playa-pdf>=0.3.1"]
 description = "Tool to extract and pretty-print PDF annotations for reviewing"
 readme = "README.md"
 license = {file = "LICENSE.txt"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 name = "pdfannots"
 dynamic = ["version"]
 requires-python = ">=3.8"
-dependencies = ["pdfminer.six >= 20220319, != 20240706"]
+dependencies = ["paves", "playa-pdf>=0.3.0"]
 description = "Tool to extract and pretty-print PDF annotations for reviewing"
 readme = "README.md"
 license = {file = "LICENSE.txt"}

--- a/tests.py
+++ b/tests.py
@@ -9,7 +9,7 @@ import typing as typ
 import unittest
 from datetime import datetime, timedelta, timezone
 
-import pdfminer.layout
+from paves.miner import LAParams
 
 import pdfannots
 import pdfannots.utils
@@ -38,7 +38,7 @@ class ExtractionTestBase(unittest.TestCase):
 
     # Permit a test to customise the columns_per_page or LAParams
     columns_per_page: typ.Optional[int] = None
-    laparams = pdfminer.layout.LAParams()
+    laparams = LAParams()
 
     def setUp(self) -> None:
         path = pathlib.Path(__file__).parent / 'tests' / self.filename
@@ -320,6 +320,7 @@ class MarkdownPrinterTest(PrinterTestBase):
 
         page_numbers = []
         for line in p.print_file('dummyfile', self.doc):
+            print(line)
             m = re.match(r'.+Page #([0-9])', line)
             if m:
                 page_numbers.append(m[1])

--- a/tests.py
+++ b/tests.py
@@ -320,7 +320,6 @@ class MarkdownPrinterTest(PrinterTestBase):
 
         page_numbers = []
         for line in p.print_file('dummyfile', self.doc):
-            print(line)
             m = re.match(r'.+Page #([0-9])', line)
             if m:
                 page_numbers.append(m[1])


### PR DESCRIPTION
As the subject says!  This helped me fix a very annoying bug, so I'm glad I did it.

It's very marginally faster, and you should also get extra robustness to broken PDFs.

Getting it to support the parallel processing that PLAYA can do is a bit more work, but I might give it a try another day...