### PR TITLE
Highlight color name

### DIFF
--- a/pdfannots/printer/markdown.py
+++ b/pdfannots/printer/markdown.py
@@ -348,7 +348,7 @@ class GroupedMarkdownPrinter(MarkdownPrinter):
                 yield fmt_header("Highlights")
 
                 for color, annots in highlights_by_color.items():
-                    yield fmt_header(f"Color: {color.ashex()}", level=3)
+                    yield fmt_header(f"Color: {color.name()} ({color.ashex()})", level=3)
                     for a in annots:
                         yield self.format_annot(a, document)
 

--- a/pdfannots/types.py
+++ b/pdfannots/types.py
@@ -578,6 +578,40 @@ class RGB(typ.NamedTuple):
         green_hex = format(int(self.green * 255), '02x')
         blue_hex = format(int(self.blue * 255), '02x')
         return red_hex + green_hex + blue_hex
+   
+    def name(self) -> str:
+        high = 200, low = 100
 
+        if self.red > max(self.green, self.blue) * 1.5:                                             # Red is dominant
+            return "Red"
+        elif self.green > max(self.red, self.blue) * 1.5:                                           # Green is dominant 
+            return "Green"
+        elif self.blue > max(self.red, self.green) * 1.5:                                           # Blue is dominant
+            return "Blue"
+        # Check for yellow (red and green mix)
+        elif self.red > high/255 and self.green > high/255 and self.blue < low/255:                 # Red and Green dominate
+            return "Yellow"
+        # Check for purple (red and blue)
+        elif self.red > low/255 and self.blue > low/255 and self.green < min(self.red, self.blue):  # Red and Blue dominate
+            return "Purple"
+        
+        # Check color which didn't fit into category
+        max_value = max(self.red, self.green, self.blue)
+        if self.red == max_value and self.green == max_value:
+            return "Yellow"
+        elif self.red == max_value:
+            if (self.blue > self.green):
+                return "Purple"
+            else: 
+                return "Red"                                                                        # Checked for yellow in 3rd above elif
+        elif self.green == max_value:
+            return "Green"
+        else:
+            if self.red > self.green:
+                return "Purple"
+            else:
+                return "Blue"    
+    
+             
     def __str__(self) -> str:
         return f"RGB({self.ashex()})"

--- a/pdfannots/types.py
+++ b/pdfannots/types.py
@@ -580,7 +580,7 @@ class RGB(typ.NamedTuple):
         return red_hex + green_hex + blue_hex
    
     def name(self) -> str:
-        high = 200, low = 100
+        high, low = 200, 100
 
         if self.red > max(self.green, self.blue) * 1.5:                                             # Red is dominant
             return "Red"


### PR DESCRIPTION
Issue [#109](https://github.com/0xabu/pdfannots/issues/109#issue-2900417232)

Simple way of getting the names of colors. Tested on iOS and Firefox highlights.

What do you think?