### PR TITLE
test with new pdfminer & python versions

### DIFF
--- a/.github/workflows/python-checks.yml
+++ b/.github/workflows/python-checks.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/python-checks.yml
+++ b/.github/workflows/python-checks.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/python-checks.yml
+++ b/.github/workflows/python-checks.yml
@@ -26,8 +26,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install flake8 mypy autopep8 pytest
-        pip install -r requirements.txt
+        pip install -r requirements-dev.txt
     - name: Type check with mypy
       run: mypy .
     - name: Lint with flake8

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,12 +18,6 @@ classifiers = [
     "Topic :: Text Processing",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11",
-    "Programming Language :: Python :: 3.12",
-    "Programming Language :: Python :: 3.13",
 ]
 
 [project.scripts]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,6 @@
+# dev/test requirements for pdfannots (not required for everyday use)
+-r requirements.txt
+autopep8 == 2.3.2
+flake8 == 7.3.0
+mypy == 1.18.2
+pytest == 9.0.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,4 +3,4 @@
 autopep8 == 2.3.2
 flake8 == 7.3.0
 mypy == 1.18.2
-pytest == 9.0.0
+pytest >= 8.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-# pip dev/test requirements for pdfannots
+# general requirements for pdfannots
 # Use as: pip3 install -r requirements.txt
 
 pdfminer.six == 20251107

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-# pip requirements for pdfannots
+# pip dev/test requirements for pdfannots
 # Use as: pip3 install -r requirements.txt
 
-pdfminer.six == 20231228
+pdfminer.six == 20251107

--- a/tests.py
+++ b/tests.py
@@ -5,6 +5,7 @@ import json
 import operator
 import pathlib
 import re
+import sys
 import typing as typ
 import unittest
 from datetime import datetime, timedelta, timezone
@@ -48,11 +49,13 @@ class ExtractionTestBase(unittest.TestCase):
             self.annots = [a for p in self.doc.pages for a in p.annots]
             self.outlines = [o for p in self.doc.pages for o in p.outlines]
 
-    def assertEndsWith(self, bigstr: str, suffix: str) -> None:
-        self.assertEqual(bigstr[-len(suffix):], suffix)
+    if sys.version_info < (3, 14):
+        def assertEndsWith(self, bigstr: str, suffix: str) -> None:
+            self.assertEqual(bigstr[-len(suffix):], suffix)
 
-    def assertStartsWith(self, bigstr: str, prefix: str) -> None:
-        self.assertEqual(bigstr[:len(prefix)], prefix)
+    if sys.version_info < (3, 14):
+        def assertStartsWith(self, bigstr: str, prefix: str) -> None:
+            self.assertEqual(bigstr[:len(prefix)], prefix)
 
 
 class ExtractionTests(ExtractionTestBase):


### PR DESCRIPTION
 * stop testing EOL Python 3.8, although we still nominally support it -- we can drop it but for now there's no harm
 * clean up dependencies a bit