### PR TITLE
Group comments by color as well with --group-highlights-by-color 

### DIFF
--- a/pdfannots/cli.py
+++ b/pdfannots/cli.py
@@ -66,7 +66,7 @@ def parse_args() -> typ.Tuple[argparse.Namespace, LAParams]:
         "--group-highlights-by-color",
         dest="group_highlights_by_color",
         default=False, action="store_true",
-        help="Group highlights by color in grouped output."
+        help="Group highlights and comments by color in grouped output."
     )
 
     g.add_argument("-s", "--sections", metavar="SEC", nargs="*",

--- a/pdfannots/cli.py
+++ b/pdfannots/cli.py
@@ -13,7 +13,7 @@ from .printer.json import JsonPrinter
 
 MD_FORMAT_ARGS = frozenset([
     'condense',
-    'group_highlights_by_color',
+    'group_by_color',
     'page_number_offset',
     'print_filename',
     'sections',
@@ -63,8 +63,8 @@ def parse_args() -> typ.Tuple[argparse.Namespace, LAParams]:
         help="Emit annotations in order, don't group into sections."
     )
     mutex_group.add_argument(
-        "--group-highlights-by-color",
-        dest="group_highlights_by_color",
+        "--group-by-color",
+        dest="group_by_color",
         default=False, action="store_true",
         help="Group highlights and comments by color in grouped output."
     )

--- a/pdfannots/printer/markdown.py
+++ b/pdfannots/printer/markdown.py
@@ -294,12 +294,12 @@ class GroupedMarkdownPrinter(MarkdownPrinter):
         self,
         *,
         sections: typ.Sequence[str] = ALL_SECTIONS,  # controls the order of sections output
-        group_highlights_by_color: bool = False,     # Whether to group highlights by color
+        group_by_color: bool = False,                # Whether to group by color
         **kwargs: typ.Any                            # other args -- see superclass
     ) -> None:
         super().__init__(**kwargs)
         self.sections = sections
-        self.group_highlights_by_color = group_highlights_by_color
+        self.group_by_color = group_by_color
         self._fmt_header_called: bool
 
     def emit_body(
@@ -328,20 +328,20 @@ class GroupedMarkdownPrinter(MarkdownPrinter):
 
         # Partition annotations into nits, comments, and highlights.
         nits: typ.List[Annotation] = []
-        comments: typ.List[Annotation] = []
         highlights: typ.List[Annotation] = []  # When grouping by color holds only undefined annots
         highlights_by_color: typ.DefaultDict[RGB, typ.List[Annotation]] = defaultdict(list)
+        comments: typ.List[Annotation] = []
         comments_by_color: typ.DefaultDict[RGB, typ.List[Annotation]] = defaultdict(list)
         for a in document.iter_annots():
             if a.subtype in self.ANNOT_NITS:
                 nits.append(a)
             elif a.contents:
-                if self.group_highlights_by_color and a.color:
+                if self.group_by_color and a.color:
                     comments_by_color[a.color].append(a)
                 else:
                     comments.append(a)
             elif a.subtype == AnnotationType.Highlight:
-                if self.group_highlights_by_color and a.color:
+                if self.group_by_color and a.color:
                     highlights_by_color[a.color].append(a)
                 else:
                     highlights.append(a)
@@ -355,7 +355,7 @@ class GroupedMarkdownPrinter(MarkdownPrinter):
                     for a in annots:
                         yield self.format_annot(a, document)
 
-                if highlights and self.group_highlights_by_color:
+                if highlights and self.group_by_color:
                     yield fmt_header("Color: undefined", level=3)
 
                 for a in highlights:
@@ -369,7 +369,7 @@ class GroupedMarkdownPrinter(MarkdownPrinter):
                     for a in annots:
                         yield self.format_annot(a, document)
 
-                if comments and self.group_highlights_by_color:
+                if comments and self.group_by_color:
                     yield fmt_header("Color: undefined", level=3)
 
                 for a in comments:

--- a/pdfannots/printer/markdown.py
+++ b/pdfannots/printer/markdown.py
@@ -331,12 +331,15 @@ class GroupedMarkdownPrinter(MarkdownPrinter):
         comments: typ.List[Annotation] = []
         highlights: typ.List[Annotation] = []  # When grouping by color holds only undefined annots
         highlights_by_color: typ.DefaultDict[RGB, typ.List[Annotation]] = defaultdict(list)
-
+        comments_by_color: typ.DefaultDict[RGB, typ.List[Annotation]] = defaultdict(list)
         for a in document.iter_annots():
             if a.subtype in self.ANNOT_NITS:
                 nits.append(a)
             elif a.contents:
-                comments.append(a)
+                if self.group_highlights_by_color and a.color:
+                    comments_by_color[a.color].append(a)
+                else:
+                    comments.append(a)
             elif a.subtype == AnnotationType.Highlight:
                 if self.group_highlights_by_color and a.color:
                     highlights_by_color[a.color].append(a)
@@ -358,8 +361,17 @@ class GroupedMarkdownPrinter(MarkdownPrinter):
                 for a in highlights:
                     yield self.format_annot(a, document)
 
-            if comments and secname == 'comments':
+            if (comments or comments_by_color) and secname == 'comments':
                 yield fmt_header("Detailed comments")
+
+                for color, annots in comments_by_color.items():
+                    yield fmt_header(f"Color: {color.ashex()}", level=3)
+                    for a in annots:
+                        yield self.format_annot(a, document)
+
+                if comments and self.group_highlights_by_color:
+                    yield fmt_header("Color: undefined", level=3)
+
                 for a in comments:
                     yield self.format_annot(a, document)
 

--- a/tests.py
+++ b/tests.py
@@ -342,7 +342,7 @@ class MarkdownPrinterTest(PrinterTestBase):
         self.assertGreater(charcount, 900)
 
     def test_multicolorgrouping(self) -> None:
-        p = GroupedMarkdownPrinter(group_highlights_by_color=True)
+        p = GroupedMarkdownPrinter(group_by_color=True)
 
         linecount = 0
         charcount = 0


### PR DESCRIPTION
This groups comments by color in the markdown output. It's analogous to what #79 did to highlights. Whereas #79 considered an internal-only use case (grouping highlights for the reviewer's own use), I'm using the groups to send back to the authors and would like colors to represent different "levels" of comment (e.g. typographical/minor vs. needs more discussion and a real response).

I considered adding another flag (`--group-comments-by-color`) or renaming the flag (`--group-by-color`) but thought this might be simple enough as is. What do you think?